### PR TITLE
Allow working together with Inventory+ weightless categories

### DIFF
--- a/dist/VariantEncumbrance.js
+++ b/dist/VariantEncumbrance.js
@@ -138,8 +138,15 @@ function convertItemSet(actorEntity) {
 	let itemSet = {};
 	const weightlessCategoryIds = [];
 	const inventoryPlusCategories = actorEntity.getFlag('inventory-plus', 'categorys');
+	console.log(inventoryPlusCategories);
 	if (inventoryPlusCategories) {
 		for (const categoryId in inventoryPlusCategories) {
+			if (inventoryPlusCategories[categoryId]?.ownWeight != 0) {
+				itemSet["i+" + categoryId] = {
+					_id: "i+" + categoryId,
+					totalWeight: inventoryPlusCategories[categoryId]?.ownWeight
+				};
+			}
 			if (inventoryPlusCategories.hasOwnProperty(categoryId) && inventoryPlusCategories[categoryId]?.ignoreWeight) {
 				weightlessCategoryIds.push(categoryId);
 			}
@@ -303,7 +310,9 @@ function calculateEncumbrance(actorEntity, itemSet) {
 				appliedWeight *= game.settings.get("VariantEncumbrance", "equippedMultiplier");
 			}
 		} else {
-			appliedWeight *= game.settings.get("VariantEncumbrance", "unequippedMultiplier");
+			if (!item._id.startsWith("i+")) {
+				appliedWeight *= game.settings.get("VariantEncumbrance", "unequippedMultiplier");
+			}
 		}
 		totalWeight += appliedWeight;
 	});

--- a/dist/VariantEncumbrance.js
+++ b/dist/VariantEncumbrance.js
@@ -136,8 +136,19 @@ function veItem(item) {
 
 function convertItemSet(actorEntity) {
 	let itemSet = {};
+	const weightlessCategoryIds = [];
+	const inventoryPlusCategories = actorEntity.getFlag('inventory-plus', 'categorys');
+	if (inventoryPlusCategories) {
+		for (const categoryId in inventoryPlusCategories) {
+			if (inventoryPlusCategories.hasOwnProperty(categoryId) && inventoryPlusCategories[categoryId]?.ignoreWeight) {
+				weightlessCategoryIds.push(categoryId);
+			}
+		}
+	}
 	actorEntity.items.forEach(item => {
-		if (item.data.data.weight != undefined) {
+		const hasWeight = !!item.data.data.weight;
+		const isNotInWeightlessCategory = weightlessCategoryIds.indexOf(item.getFlag('inventory-plus', 'category')) < 0;
+		if (hasWeight && isNotInWeightlessCategory) {
 			itemSet[item.data._id] = veItem(item.data);
 		}
 	});


### PR DESCRIPTION
This adds a tie-in to Inventory+ v0.3.1, which has weightless categories in the character sheet.
If an item is in one of these categories, its weight will count as 0.

Fixes #12 