### PR TITLE
Fix: Prevent stacking of Effects

### DIFF
--- a/dist/VariantEncumbrance.js
+++ b/dist/VariantEncumbrance.js
@@ -210,41 +210,20 @@ function updateEncumbrance(actorEntity, itemSet) {
 				break;
 		}
 
+		const changes = ['walk', 'swim', 'fly', 'climb', 'burrow'].map((movementType) => {
+			const changeKey = "data.attributes.movement." + movementType;
+			return {
+				key: changeKey,
+				value: changeValue,
+				mode: changeMode,
+				priority: 1000
+			};
+		});
+
 		let effect = {
 			label: effectName,
 			icon: "icons/tools/smithing/anvil.webp",
-			changes: [
-				{
-					key: "data.attributes.movement.walk",
-					value: changeValue,
-					mode: changeMode,
-					priority: 1000
-				},
-				{
-					key: "data.attributes.movement.swim",
-					value: changeValue,
-					mode: changeMode,
-					priority: 1000
-				},
-				{
-					key: "data.attributes.movement.fly",
-					value: changeValue,
-					mode: changeMode,
-					priority: 1000
-				},
-				{
-					key: "data.attributes.movement.climb",
-					value: changeValue,
-					mode: changeMode,
-					priority: 1000
-				},
-				{
-					key: "data.attributes.movement.burrow",
-					value: changeValue,
-					mode: changeMode,
-					priority: 1000
-				}
-			],
+			changes: changes,
 			flags: {
 				VariantEncumbrance: {
 					tier: encumbranceData.encumbranceTier

--- a/dist/VariantEncumbrance.js
+++ b/dist/VariantEncumbrance.js
@@ -174,13 +174,13 @@ function updateEncumbrance(actorEntity, itemSet) {
 	console.log("#### VE DEBUG: " + effectTierChanged + " | " + effectTiersPresent);
 	if (effectTierChanged || effectTiersPresent == 0) {
 		if (encumbranceData.encumbranceTier != 0) {
-			let changeMode = encumbranceData.encumbranceTier >= 3 ? 1 : 2;
-			let changeValue = encumbranceData.encumbranceTier >= 3 ? 0 : encumbranceData.speedDecrease * -1;
+			let [changeMode, changeValue] = encumbranceData.encumbranceTier >= 3 ?
+				[ACTIVE_EFFECT_MODES.MULTIPLY, 0] :
+				[ACTIVE_EFFECT_MODES.ADD, encumbranceData.speedDecrease * -1];
 			if (!game.settings.get("VariantEncumbrance", "useVariantEncumbrance")) {
-				changeMode = 2;
+				changeMode = ACTIVE_EFFECT_MODES.ADD;
 				changeValue = 0;
 			}
-			let effectIconURL;
 			let effectName;
 			switch (encumbranceData.encumbranceTier) {
 				case 1:

--- a/dist/VariantEncumbrance.js
+++ b/dist/VariantEncumbrance.js
@@ -16,6 +16,17 @@ import { preloadTemplates } from './module/preloadTemplates.js';
 import { DND5E } from "../../systems/dnd5e/module/config.js";
 
 /* ------------------------------------ */
+/* Constants         					*/
+/* ------------------------------------ */
+const ENCUMBRANCE_TIERS = {
+	NONE: 0,
+	LIGHT: 1,
+	HEAVY: 2,
+	MAX: 3,
+};
+
+
+/* ------------------------------------ */
 /* Initialize module					*/
 /* ------------------------------------ */
 Hooks.once('init', async function () {
@@ -72,13 +83,13 @@ Hooks.on('renderActorSheet', function (actorSheet, htmlElement, actorObject) {
 		encumbranceElements[0].classList.remove("medium");
 		encumbranceElements[0].classList.remove("heavy");
 
-		if (encumbranceData.encumbranceTier == 1) {
+		if (encumbranceData.encumbranceTier === ENCUMBRANCE_TIERS.LIGHT) {
 			encumbranceElements[0].classList.add("medium");
 		}
-		if (encumbranceData.encumbranceTier == 2) {
+		if (encumbranceData.encumbranceTier === ENCUMBRANCE_TIERS.HEAVY) {
 			encumbranceElements[0].classList.add("heavy");
 		}
-		if (encumbranceData.encumbranceTier == 3) {
+		if (encumbranceData.encumbranceTier === ENCUMBRANCE_TIERS.MAX) {
 			encumbranceElements[0].classList.add("max");
 		}
 
@@ -177,7 +188,7 @@ function updateEncumbrance(actorEntity, itemSet) {
 	if (!shouldHaveEncumbrance && hasEncumbrance) {
 		effectEntityPresent.delete();
 	} else if (shouldHaveEncumbrance) {
-		let [changeMode, changeValue] = encumbranceData.encumbranceTier >= 3 ?
+		let [changeMode, changeValue] = encumbranceData.encumbranceTier >= ENCUMBRANCE_TIERS.MAX ?
 			[ACTIVE_EFFECT_MODES.MULTIPLY, 0] :
 			[ACTIVE_EFFECT_MODES.ADD, encumbranceData.speedDecrease * -1];
 		if (!game.settings.get("VariantEncumbrance", "useVariantEncumbrance")) {
@@ -186,13 +197,13 @@ function updateEncumbrance(actorEntity, itemSet) {
 		}
 		let effectName;
 		switch (encumbranceData.encumbranceTier) {
-			case 1:
+			case ENCUMBRANCE_TIERS.LIGHT:
 				effectName = "Lightly Encumbered";
 				break;
-			case 2:
+			case ENCUMBRANCE_TIERS.HEAVY:
 				effectName = "Heavily Encumbered";
 				break
-			case 3:
+			case ENCUMBRANCE_TIERS.MAX:
 				effectName = "Overburdened";
 				break;
 			default:
@@ -314,14 +325,14 @@ function calculateEncumbrance(actorEntity, itemSet) {
 	let encumbranceTier = 0;
 	if (totalWeight >= lightMax && totalWeight < mediumMax) {
 		speedDecrease = 10;
-		encumbranceTier = 1;
+		encumbranceTier = ENCUMBRANCE_TIERS.LIGHT;
 	}
 	if (totalWeight >= mediumMax && totalWeight < heavyMax) {
 		speedDecrease = 20;
-		encumbranceTier = 2;
+		encumbranceTier = ENCUMBRANCE_TIERS.HEAVY;
 	}
 	if (totalWeight >= heavyMax) {
-		encumbranceTier = 3;
+		encumbranceTier = ENCUMBRANCE_TIERS.MAX;
 	}
 
 	return {

--- a/dist/VariantEncumbrance.js
+++ b/dist/VariantEncumbrance.js
@@ -260,9 +260,17 @@ function updateEncumbrance(actorEntity, itemSet) {
 		}
 	}
 	actorEntity.applyActiveEffects();
-	actorEntity.setFlag("VariantEncumbrance", "speed", actorEntity.data.data.attributes.movement.walk);
-	actorEntity.setFlag("VariantEncumbrance", "tier", encumbranceData.encumbranceTier);
-	actorEntity.setFlag("VariantEncumbrance", "weight", encumbranceData.totalWeight);
+
+	const { speed, tier, weight } = (actorEntity.data.flags.VariantEncumbrance || {});
+	if (speed !== actorEntity.data.data.attributes.movement.walk) {
+		actorEntity.setFlag("VariantEncumbrance", "speed", actorEntity.data.data.attributes.movement.walk);
+	}
+	if (tier !== encumbranceData.encumbranceTier) {
+		actorEntity.setFlag("VariantEncumbrance", "tier", encumbranceData.encumbranceTier);
+	}
+	if (weight !== encumbranceData.totalWeight) {
+		actorEntity.setFlag("VariantEncumbrance", "weight", encumbranceData.totalWeight);
+	}
 }
 
 function calculateEncumbrance(actorEntity, itemSet) {


### PR DESCRIPTION
Fixes #16

It seems that for some reason, the code managed to get itself into a state where the previously applied Effects were not recognised as having already been applied. As a result, Effects were not being removed when there were duplicates _if_ the Effect tier was the same as the previous tier, which caused massively stacking effects.

This change updates the code so that regardless of the existing tier, we always delete other Effects (there can only be one). Then we update the effect to match what the encumbrance should be.

The core part of this code is in commit https://github.com/VanirDev/VariantEncumbrance/commit/5c4dd44d3e89508c525760b7617154cfd108db3d which can be reviewed standalone; the remainder of the commits are simplifications to the code. I can drop these commits if you don't feel they are appropriate.