### PR TITLE
Fix: Run code once per update to prevent stacking

### DIFF
--- a/dist/VariantEncumbrance.js
+++ b/dist/VariantEncumbrance.js
@@ -210,41 +210,20 @@ function updateEncumbrance(actorEntity, itemSet) {
 				break;
 		}
 
+		const changes = ['walk', 'swim', 'fly', 'climb', 'burrow'].map((movementType) => {
+			const changeKey = "data.attributes.movement." + movementType;
+			return {
+				key: changeKey,
+				value: changeValue,
+				mode: changeMode,
+				priority: 1000
+			};
+		});
+
 		let effect = {
 			label: effectName,
 			icon: "icons/tools/smithing/anvil.webp",
-			changes: [
-				{
-					key: "data.attributes.movement.walk",
-					value: changeValue,
-					mode: changeMode,
-					priority: 1000
-				},
-				{
-					key: "data.attributes.movement.swim",
-					value: changeValue,
-					mode: changeMode,
-					priority: 1000
-				},
-				{
-					key: "data.attributes.movement.fly",
-					value: changeValue,
-					mode: changeMode,
-					priority: 1000
-				},
-				{
-					key: "data.attributes.movement.climb",
-					value: changeValue,
-					mode: changeMode,
-					priority: 1000
-				},
-				{
-					key: "data.attributes.movement.burrow",
-					value: changeValue,
-					mode: changeMode,
-					priority: 1000
-				}
-			],
+			changes: changes,
 			flags: {
 				VariantEncumbrance: {
 					tier: encumbranceData.encumbranceTier

--- a/dist/VariantEncumbrance.js
+++ b/dist/VariantEncumbrance.js
@@ -174,13 +174,13 @@ function updateEncumbrance(actorEntity, itemSet) {
 	console.log("#### VE DEBUG: " + effectTierChanged + " | " + effectTiersPresent);
 	if (effectTierChanged || effectTiersPresent == 0) {
 		if (encumbranceData.encumbranceTier != 0) {
-			let changeMode = encumbranceData.encumbranceTier >= 3 ? 1 : 2;
-			let changeValue = encumbranceData.encumbranceTier >= 3 ? 0 : encumbranceData.speedDecrease * -1;
+			let [changeMode, changeValue] = encumbranceData.encumbranceTier >= 3 ?
+				[ACTIVE_EFFECT_MODES.MULTIPLY, 0] :
+				[ACTIVE_EFFECT_MODES.ADD, encumbranceData.speedDecrease * -1];
 			if (!game.settings.get("VariantEncumbrance", "useVariantEncumbrance")) {
-				changeMode = 2;
+				changeMode = ACTIVE_EFFECT_MODES.ADD;
 				changeValue = 0;
 			}
-			let effectIconURL;
 			let effectName;
 			switch (encumbranceData.encumbranceTier) {
 				case 1:

--- a/dist/VariantEncumbrance.js
+++ b/dist/VariantEncumbrance.js
@@ -16,6 +16,17 @@ import { preloadTemplates } from './module/preloadTemplates.js';
 import { DND5E } from "../../systems/dnd5e/module/config.js";
 
 /* ------------------------------------ */
+/* Constants         					*/
+/* ------------------------------------ */
+const ENCUMBRANCE_TIERS = {
+	NONE: 0,
+	LIGHT: 1,
+	HEAVY: 2,
+	MAX: 3,
+};
+
+
+/* ------------------------------------ */
 /* Initialize module					*/
 /* ------------------------------------ */
 Hooks.once('init', async function () {
@@ -72,13 +83,13 @@ Hooks.on('renderActorSheet', function (actorSheet, htmlElement, actorObject) {
 		encumbranceElements[0].classList.remove("medium");
 		encumbranceElements[0].classList.remove("heavy");
 
-		if (encumbranceData.encumbranceTier == 1) {
+		if (encumbranceData.encumbranceTier === ENCUMBRANCE_TIERS.LIGHT) {
 			encumbranceElements[0].classList.add("medium");
 		}
-		if (encumbranceData.encumbranceTier == 2) {
+		if (encumbranceData.encumbranceTier === ENCUMBRANCE_TIERS.HEAVY) {
 			encumbranceElements[0].classList.add("heavy");
 		}
-		if (encumbranceData.encumbranceTier == 3) {
+		if (encumbranceData.encumbranceTier === ENCUMBRANCE_TIERS.MAX) {
 			encumbranceElements[0].classList.add("max");
 		}
 
@@ -177,7 +188,7 @@ function updateEncumbrance(actorEntity, itemSet) {
 	if (!shouldHaveEncumbrance && hasEncumbrance) {
 		effectEntityPresent.delete();
 	} else if (shouldHaveEncumbrance) {
-		let [changeMode, changeValue] = encumbranceData.encumbranceTier >= 3 ?
+		let [changeMode, changeValue] = encumbranceData.encumbranceTier >= ENCUMBRANCE_TIERS.MAX ?
 			[ACTIVE_EFFECT_MODES.MULTIPLY, 0] :
 			[ACTIVE_EFFECT_MODES.ADD, encumbranceData.speedDecrease * -1];
 		if (!game.settings.get("VariantEncumbrance", "useVariantEncumbrance")) {
@@ -186,13 +197,13 @@ function updateEncumbrance(actorEntity, itemSet) {
 		}
 		let effectName;
 		switch (encumbranceData.encumbranceTier) {
-			case 1:
+			case ENCUMBRANCE_TIERS.LIGHT:
 				effectName = "Lightly Encumbered";
 				break;
-			case 2:
+			case ENCUMBRANCE_TIERS.HEAVY:
 				effectName = "Heavily Encumbered";
 				break
-			case 3:
+			case ENCUMBRANCE_TIERS.MAX:
 				effectName = "Overburdened";
 				break;
 			default:
@@ -314,14 +325,14 @@ function calculateEncumbrance(actorEntity, itemSet) {
 	let encumbranceTier = 0;
 	if (totalWeight >= lightMax && totalWeight < mediumMax) {
 		speedDecrease = 10;
-		encumbranceTier = 1;
+		encumbranceTier = ENCUMBRANCE_TIERS.LIGHT;
 	}
 	if (totalWeight >= mediumMax && totalWeight < heavyMax) {
 		speedDecrease = 20;
-		encumbranceTier = 2;
+		encumbranceTier = ENCUMBRANCE_TIERS.HEAVY;
 	}
 	if (totalWeight >= heavyMax) {
-		encumbranceTier = 3;
+		encumbranceTier = ENCUMBRANCE_TIERS.MAX;
 	}
 
 	return {

--- a/dist/VariantEncumbrance.js
+++ b/dist/VariantEncumbrance.js
@@ -260,9 +260,17 @@ function updateEncumbrance(actorEntity, itemSet) {
 		}
 	}
 	actorEntity.applyActiveEffects();
-	actorEntity.setFlag("VariantEncumbrance", "speed", actorEntity.data.data.attributes.movement.walk);
-	actorEntity.setFlag("VariantEncumbrance", "tier", encumbranceData.encumbranceTier);
-	actorEntity.setFlag("VariantEncumbrance", "weight", encumbranceData.totalWeight);
+
+	const { speed, tier, weight } = (actorEntity.data.flags.VariantEncumbrance || {});
+	if (speed !== actorEntity.data.data.attributes.movement.walk) {
+		actorEntity.setFlag("VariantEncumbrance", "speed", actorEntity.data.data.attributes.movement.walk);
+	}
+	if (tier !== encumbranceData.encumbranceTier) {
+		actorEntity.setFlag("VariantEncumbrance", "tier", encumbranceData.encumbranceTier);
+	}
+	if (weight !== encumbranceData.totalWeight) {
+		actorEntity.setFlag("VariantEncumbrance", "weight", encumbranceData.totalWeight);
+	}
 }
 
 function calculateEncumbrance(actorEntity, itemSet) {

--- a/dist/VariantEncumbrance.js
+++ b/dist/VariantEncumbrance.js
@@ -38,7 +38,7 @@ Hooks.once('init', async function () {
 	registerSettings();
 	DND5E.encumbrance.strMultiplier = game.settings.get("VariantEncumbrance", "heavyMultiplier");
 	DND5E.encumbrance.currencyPerWeight = game.settings.get("VariantEncumbrance", "currencyWeight");
-	CONFIG.debug.hooks = true;
+	// CONFIG.debug.hooks = true; // For debugging only
 	// Preload Handlebars templates
 	await preloadTemplates();
 
@@ -49,9 +49,7 @@ Hooks.once('init', async function () {
 /* Setup module							*/
 /* ------------------------------------ */
 Hooks.once('setup', function () {
-	// Do anything after initialization but before
-	// ready
-
+	// Do anything after initialization but before ready
 });
 
 /* ------------------------------------ */
@@ -67,7 +65,7 @@ Hooks.on('renderActorSheet', function (actorSheet, htmlElement, actorObject) {
 		let encumbranceData = calculateEncumbrance(actorEntity);
 
 		let encumbranceElements;
-		if (htmlElement[0].tagName == "FORM" && htmlElement[0].id == "") {
+		if (htmlElement[0].tagName === "FORM" && htmlElement[0].id === "") {
 			encumbranceElements = htmlElement.find('.encumbrance')[0].children;
 		} else {
 			encumbranceElements = htmlElement.find('.encumbrance')[0].children;
@@ -104,11 +102,8 @@ Hooks.on('renderActorSheet', function (actorSheet, htmlElement, actorObject) {
 Hooks.on('updateOwnedItem', function (actorEntity, updatedItem, updateChanges, _, userId) {
 	if (game.userId !== userId) {
 		// Only act if we initiated the update ourselves
-		console.log('VE | Update triggered by other user');
 		return;
 	}
-
-	console.log('VE | Processing item update');
 
 	updateEncumbrance(actorEntity, updatedItem);
 });
@@ -116,11 +111,8 @@ Hooks.on('updateOwnedItem', function (actorEntity, updatedItem, updateChanges, _
 Hooks.on('createOwnedItem', function (actorEntity, createdItem, _, userId) {
 	if (game.userId !== userId) {
 		// Only act if we initiated the update ourselves
-		console.log('VE | Update triggered by other user');
 		return;
 	}
-
-	console.log('VE | Processing item update');
 
 	updateEncumbrance(actorEntity);
 });
@@ -128,11 +120,8 @@ Hooks.on('createOwnedItem', function (actorEntity, createdItem, _, userId) {
 Hooks.on('deleteOwnedItem', function (actorEntity, deletedItem, _, userId) {
 	if (game.userId !== userId) {
 		// Only act if we initiated the update ourselves
-		console.log('VE | Update triggered by other user');
 		return;
 	}
-
-	console.log('VE | Processing item update');
 
 	updateEncumbrance(actorEntity);
 })
@@ -155,7 +144,7 @@ function convertItemSet(actorEntity) {
 			itemSet[item.data._id] = veItem(item.data);
 		}
 	});
-	// console.log(itemSet);
+
 	return itemSet;
 }
 
@@ -179,7 +168,7 @@ async function updateEncumbrance(actorEntity, updatedItem) {
 				effectEntityPresent = effectEntity;
 			} else {
 				// Cannot have more than one effect tier present at any one time
-				console.log("VE | deleting duplicate effect", effectEntity);
+				console.log("VariantEncumbrance | deleting duplicate effect", effectEntity);
 				await effectEntity.delete();
 			}
 		}
@@ -257,27 +246,27 @@ async function updateEncumbrance(actorEntity, updatedItem) {
 }
 
 function calculateEncumbrance(actorEntity, itemSet) {
-	if (actorEntity.data.type != "character") {
+	if (actorEntity.data.type !== "character") {
 		console.log("ERROR: NOT A CHARACTER");
 		return null;
 	}
 
-	if (itemSet == null) {
+	if (itemSet === null) {
 		itemSet = convertItemSet(actorEntity);
 	}
 
 	let speedDecrease = 0;
-	var totalWeight = 0;
-	var strengthScore = actorEntity.data.data.abilities.str.value;
+	let totalWeight = 0;
+	let strengthScore = actorEntity.data.data.abilities.str.value;
 	if (game.settings.get("VariantEncumbrance", "sizeMultipliers")) {
-		var size = actorEntity.data.data.traits.size;
-		if (size == "tiny") {
+		const size = actorEntity.data.data.traits.size;
+		if (size === "tiny") {
 			strengthScore /= 2;
-		} else if (size == "lg") {
+		} else if (size === "lg") {
 			strengthScore *= 2;
-		} else if (size == "huge") {
+		} else if (size === "huge") {
 			strengthScore *= 4;
-		} else if (size == "grg") {
+		} else if (size === "grg") {
 			strengthScore *= 8;
 		} else {
 			strengthScore *= 1;
@@ -287,12 +276,12 @@ function calculateEncumbrance(actorEntity, itemSet) {
 			strengthScore *= 2;
 		}
 	}
-	var lightMax = game.settings.get("VariantEncumbrance", "lightMultiplier") * strengthScore;
-	var mediumMax = game.settings.get("VariantEncumbrance", "mediumMultiplier") * strengthScore;
-	var heavyMax = game.settings.get("VariantEncumbrance", "heavyMultiplier") * strengthScore;
+	const lightMax = game.settings.get("VariantEncumbrance", "lightMultiplier") * strengthScore;
+	const mediumMax = game.settings.get("VariantEncumbrance", "mediumMultiplier") * strengthScore;
+	const heavyMax = game.settings.get("VariantEncumbrance", "heavyMultiplier") * strengthScore;
 
 	Object.values(itemSet).forEach(item => {
-		var appliedWeight = item.totalWeight;
+		let appliedWeight = item.totalWeight;
 		if (item.equipped) {
 			if (item.proficient) {
 				appliedWeight *= game.settings.get("VariantEncumbrance", "profEquippedMultiplier");
@@ -306,7 +295,7 @@ function calculateEncumbrance(actorEntity, itemSet) {
 	});
 
 	if (game.settings.get("dnd5e", "currencyWeight")) {
-		var totalCoins = 0;
+		let totalCoins = 0;
 		Object.values(actorEntity.data.data.currency).forEach(count => {
 			totalCoins += count;
 		});


### PR DESCRIPTION
The core part of this update is adding a guard that only runs the updates if the current user was the one who made the change. Each of the three hooks that we subscribe to takes as a final argument the ID of the user who triggered the hook. As a result, we can ensure that only one user updates encumbrance: the one who made the change. That user _must_ be online (as they just made a change), and _must_ have permission to edit that Actor (because they were able to update items on the Actor).

Fixes #20: Because a user has to have permissions to modify an Actor to make an update, this should ensure that there are no more permission issues, since only the same user who made a change will be attempting to edit the encumbrance.

Fixes #16: By ensuring that only a single user runs the update code, we get rid of the race condition where multiple users attempt to create an Effect on the user.

There is another change to support the update of the encumbrance: Instead of deleting and re-adding encumbrance, we only ever create a single item. All other items are automatically deleted. This item is updated whenever we change encumbrance levels. If the user is unencumbered, instead of deleting the Encumbrance Effect entry, we simply deactivate it. This way, we can ensure there is never a reason to add another Encumbrance entry, even if there _were_ multiple attempts to add one.

This PR contains a few small style changes: Replacing `==` with `===` and `var` with `const` and `let` to bring the code inline with best practices. It also introduces a constant object for the encumbrance tiers, which made it easier for me to reason about the switch statements. Please feed back if these changes are acceptable, else I can revert them.