### PR TITLE
Skip updating encumbrance if tier is the same

### DIFF
--- a/dist/VariantEncumbrance.js
+++ b/dist/VariantEncumbrance.js
@@ -291,6 +291,11 @@ async function updateEncumbrance(actorEntity, updatedItem, updatedEffect, mode) 
 			return;
 	}
 
+	// Skip if name is the same.
+	if (effectName === effectEntityPresent.data.label) {
+		return;
+	}
+
 	let movementSet = ['walk', 'swim', 'fly', 'climb', 'burrow'];
 	if (actorEntity._data?.data?.attributes?.movement) {
 		movementSet = [];


### PR DESCRIPTION
At most times, there is no need to update encumbrance effects if the name is the same.

Updating the effects no matter what changed will cause some UX problems:
For example, the actor updates its item with some changes so VE updates the actor's Active Effects but due to the actor Active Effects' change, the item sheet in editing will re-render and return the description tab, it's very annoying.